### PR TITLE
 Make it harder for Mean() and StdDev() to overflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  - 1.8.x
-  - 1.9.x
   - 1.10.x
   - 1.11.x
   - master

--- a/hdr.go
+++ b/hdr.go
@@ -171,14 +171,15 @@ func (h *Histogram) Mean() float64 {
 	if h.totalCount == 0 {
 		return 0
 	}
-	var total int64
+	var mean float64
+	totalCount := float64(h.totalCount)
 	i := h.iterator()
 	for i.next() {
 		if i.countAtIdx != 0 {
-			total += i.countAtIdx * h.medianEquivalentValue(i.valueFromIdx)
+			mean += float64(i.countAtIdx*h.medianEquivalentValue(i.valueFromIdx)) / totalCount
 		}
 	}
-	return float64(total) / float64(h.totalCount)
+	return mean
 }
 
 // StdDev returns the approximate standard deviation of the recorded values.
@@ -189,16 +190,17 @@ func (h *Histogram) StdDev() float64 {
 
 	mean := h.Mean()
 	geometricDevTotal := 0.0
+	totalCount := float64(h.totalCount)
 
 	i := h.iterator()
 	for i.next() {
 		if i.countAtIdx != 0 {
 			dev := float64(h.medianEquivalentValue(i.valueFromIdx)) - mean
-			geometricDevTotal += (dev * dev) * float64(i.countAtIdx)
+			geometricDevTotal += (dev * dev) * float64(i.countAtIdx) / totalCount
 		}
 	}
 
-	return math.Sqrt(geometricDevTotal / float64(h.totalCount))
+	return math.Sqrt(geometricDevTotal)
 }
 
 // Reset deletes all recorded values and restores the histogram to its original

--- a/hdr_test.go
+++ b/hdr_test.go
@@ -67,6 +67,10 @@ func TestMean(t *testing.T) {
 	}
 }
 
+func toFixed(num float64, precision int) float64 {
+	output := math.Pow(10, float64(precision))
+	return float64(math.Round(num*output)) / output
+}
 func TestStdDev(t *testing.T) {
 	h := hdrhistogram.New(1, 10000000, 3)
 
@@ -76,7 +80,7 @@ func TestStdDev(t *testing.T) {
 		}
 	}
 
-	if v, want := h.StdDev(), 288675.1403682715; v != want {
+	if v, want := toFixed(h.StdDev(), 8), 288675.14036827; v != want {
 		t.Errorf("StdDev was %v, but expected %v", v, want)
 	}
 }


### PR DESCRIPTION
Copy of @cassava's PR from https://github.com/codahale/hdrhistogram/pull/21